### PR TITLE
Harden Debian server: ssh host keys & login limits

### DIFF
--- a/how-to-configure-hardened-debian-server/README.md
+++ b/how-to-configure-hardened-debian-server/README.md
@@ -2,8 +2,8 @@
 Title: How to configure hardened Debian server
 Description: Learn how to configure hardened Debian server.
 Author: Sun Knudsen <https://github.com/sunknudsen>
-Contributors: Sun Knudsen <https://github.com/sunknudsen>
-Reviewers:
+Contributors: Sun Knudsen <https://github.com/sunknudsen>, Go Compile <https://github.com/go-compile>
+Reviewers: Go Compile <https://github.com/go-compile>
 Publication date: 2020-11-27T10:00:26.806Z
 Listed: true
 -->
@@ -165,6 +165,18 @@ su -
 ```shell
 sed -i -E 's/^(#)?PermitRootLogin (prohibit-password|yes)/PermitRootLogin no/' /etc/ssh/sshd_config
 sed -i -E 's/^(#)?PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config
+```
+
+#### Limit login attempts and use `Ed25519` host key
+
+```shell
+sed -i -E 's/^(#)?MaxAuthTries 6/MaxAuthTries 2/' /etc/ssh/sshd_config
+sed -i -E 's/^(#)?HostKey \/etc\/ssh\/ssh_host_ed25519_key/HostKey \/etc\/ssh\/ssh_host_ed25519_key/' /etc/ssh/sshd_config
+```
+
+#### Restart SSH daemon 
+
+```shell
 systemctl restart ssh
 ```
 


### PR DESCRIPTION
Configure openssh server to use Ed25519 instead of RSA or nistp256 host keys (https://cr.yp.to/newelliptic/nistecc-20160106.pdf; https://crypto.stackexchange.com/questions/84271/why-openssh-prefers-ecdsa-nistp256-keys-over-384-and-521-and-those-over-ed255/84282#84282).

Limit login tries to single attempt per connection.