### PR TITLE
Updated guide to use `cupsctl`

### DIFF
--- a/how-to-disable-cups-printer-job-history-on-macos/README.md
+++ b/how-to-disable-cups-printer-job-history-on-macos/README.md
@@ -2,7 +2,7 @@
 Title: How to disable CUPS printer job history on macOS
 Description: Learn how to disable CUPS printer job history on macOS.
 Author: Sun Knudsen <https://github.com/sunknudsen>
-Contributors: Sun Knudsen <https://github.com/sunknudsen>
+Contributors: Sun Knudsen <https://github.com/sunknudsen>, Carl P. Corliss <https://github.com/rabbitt>
 Reviewers:
 Publication date: 2022-10-29T13:05:18.112Z
 Listed: true
@@ -18,39 +18,69 @@ Listed: true
 
 ## Setup guide
 
-### Step 1: Reconfigure CUPS:
+### Step 1: clear job history
+
+> Heads-up: purges `/var/spool/cups`.
 
 ```shell
-$  cupsctl MaxJobTime=5m PreserveJobFiles=no PreserveJobHistory=no
+$ cancel -a -x
 ```
 
-From [`cupsd.conf`](https://www.cups.org/doc/man-cupsd.conf.html) documentation:
-<dl><dt><a name="MaxJobs"></a><b>MaxJobs </b><i>number</i></dt><dd style="margin-left: 5.0em">Specifies the maximum number of simultaneous jobs that are allowed. Set to "0" to allow an unlimited number of jobs; the default is "500".</dd><dt><a name="MaxJobTime"></a><b>MaxJobTime </b><i>seconds</i></dt><dd style="margin-left: 5.0em">Specifies the maximum time a job may take to print before it is canceled.
-	Set to "0" to disable cancellation of "stuck" jobs.
-	The default is "10800" (3 hours).</dd><dt><a name="PreserveJobFiles"></a><b>PreserveJobFiles</b> Yes | No | <i>seconds</i></dt><dd style="margin-left: 5.0em">Specifies whether job files (documents) are preserved after a job is printed.
-	If a numeric value is specified, job files are preserved for the indicated number of seconds after printing.
-	The default is "86400" (preserve 1 day).</dd><dt><a name="PreserveJobHistory"></a><b>PreserveJobHistory</b> Yes | No | <i>seconds</i></dt><dd style="margin-left: 5.0em">Specifies whether the job history is preserved after a job is printed.
-	If a numeric value is specified, the job history is preserved for the indicated number of seconds after printing.
-	If "Yes", the job history is preserved until the MaxJobs limit is reached.
-	The default is "Yes".</dd></dl>
-
-### Step 2: clear job history
-
-Clear out any completed jobs using the new settings from Step 1 (note: this does not affect any active jobs in the queue)
+### Step 2: create `/usr/local/sbin` directory
 
 ```shell
-$ lpstat -W completed -o
+sudo mkdir -p /usr/local/sbin
+sudo chown ${USER}:admin /usr/local/sbin
 ```
 
-### Step 3: Setup cronjob to clear out jobs
-
-> Note: Jobs *should* automatically be purged upon completion if you're using the settings above, but *may* persist in some specific cases (e.g., if cups is restarted in the middle of a job, [see this](https://access.redhat.com/solutions/5914031)). This cron job will ensure that any jobs that persist are cleaned out using the `PreserveJobFiles` and `PreserveJobHistory` settings you defined in Step 1:
+### Step 3: create `cups.sh` script (see CUPS [docs](https://www.cups.org/doc/man-cupsd.conf.html))
 
 ```shell
-if ! crontab -l 2>/dev/null | grep -q CUPS-QUEUE-PURGE; then
-	crontab <(crontab -l 2>/dev/null; echo -en "\n# CUPS-QUEUE-PURGE: ensure that print jobs are cleaned out after they're expired\n* * * * * /usr/bin/lpstat -W completed -o")
+cat << "EOF" > /usr/local/sbin/cups.sh
+#! /bin/sh
+
+set -e
+
+if cupsctl | grep PreserveJobHistory=no > /dev/null 2>&1; then
+  exit 0
 fi
+
+cupsctl MaxJobTime=5m PreserveJobFiles=no PreserveJobHistory=no
+EOF
 ```
+
+### Step 4: make `cups.sh` executable
+
+```shell
+chmod +x /usr/local/sbin/cups.sh
+```
+
+### Step 5: create `local.cups.plist` launch daemon
+
+> Heads-up: used to make sure user-defined config persists macOS updates.
+
+```shell
+cat << "EOF" | sudo tee /Library/LaunchDaemons/local.cups.plist
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>local.cups</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/sbin/cups.sh</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+  </dict>
+</plist>
+EOF
+```
+
+### Step 6: reboot
 
 👍
 
@@ -58,10 +88,24 @@ fi
 
 ## Want things back the way they were before following this guide? No problem!
 
-### Step 1:  Reset config parameters to defaults
+### Step 1: delete `cups.sh` script
 
 ```shell
-$  cupsctl MaxJobTime= PreserveJobFiles= PreserveJobHistory=
+sudo rm /usr/local/sbin/cups.sh
 ```
+
+### Step 2: delete `local.cups.plist` launch daemon
+
+```shell
+sudo rm /Library/LaunchDaemons/local.cups.plist
+```
+
+### Step 3: revert user-defined config to CUPS defaults
+
+```shell
+cupsctl MaxJobTime= PreserveJobFiles= PreserveJobHistory=
+```
+
+### Step 4: reboot
 
 👍

--- a/how-to-disable-cups-printer-job-history-on-macos/README.md
+++ b/how-to-disable-cups-printer-job-history-on-macos/README.md
@@ -18,71 +18,39 @@ Listed: true
 
 ## Setup guide
 
-### Step 1: clear job history
-
-> Heads-up: purges `/var/spool/cups`.
+### Step 1: Reconfigure CUPS:
 
 ```shell
-$ cancel -a -x
+$  cupsctl MaxJobTime=5m PreserveJobFiles=no PreserveJobHistory=no
 ```
 
-### Step 2: create `/usr/local/sbin` directory
+From [`cupsd.conf`](https://www.cups.org/doc/man-cupsd.conf.html) documentation:
+<dl><dt><a name="MaxJobs"></a><b>MaxJobs </b><i>number</i></dt><dd style="margin-left: 5.0em">Specifies the maximum number of simultaneous jobs that are allowed. Set to "0" to allow an unlimited number of jobs; the default is "500".</dd><dt><a name="MaxJobTime"></a><b>MaxJobTime </b><i>seconds</i></dt><dd style="margin-left: 5.0em">Specifies the maximum time a job may take to print before it is canceled.
+	Set to "0" to disable cancellation of "stuck" jobs.
+	The default is "10800" (3 hours).</dd><dt><a name="PreserveJobFiles"></a><b>PreserveJobFiles</b> Yes | No | <i>seconds</i></dt><dd style="margin-left: 5.0em">Specifies whether job files (documents) are preserved after a job is printed.
+	If a numeric value is specified, job files are preserved for the indicated number of seconds after printing.
+	The default is "86400" (preserve 1 day).</dd><dt><a name="PreserveJobHistory"></a><b>PreserveJobHistory</b> Yes | No | <i>seconds</i></dt><dd style="margin-left: 5.0em">Specifies whether the job history is preserved after a job is printed.
+	If a numeric value is specified, the job history is preserved for the indicated number of seconds after printing.
+	If "Yes", the job history is preserved until the MaxJobs limit is reached.
+	The default is "Yes".</dd></dl>
+
+### Step 2: clear job history
+
+Clear out any completed jobs using the new settings from Step 1 (note: this does not affect any active jobs in the queue)
 
 ```shell
-sudo mkdir -p /usr/local/sbin
-sudo chown ${USER}:admin /usr/local/sbin
+$ lpstat -W completed -o
 ```
 
-### Step 3: create `cups.sh` script
+### Step 3: Setup cronjob to clear out jobs
+
+> Note: Jobs *should* automatically be purged upon completion if you're using the settings above, but *may* persist in some specific cases (e.g., if cups is restarted in the middle of a job, [see this](https://access.redhat.com/solutions/5914031)). This cron job will ensure that any jobs that persist are cleaned out using the `PreserveJobFiles` and `PreserveJobHistory` settings you defined in Step 1:
 
 ```shell
-cat << "EOF" > /usr/local/sbin/cups.sh
-#! /bin/sh
-
-set -e
-
-if grep -qe '^PreserveJobHistory Off$' /etc/cups/cupsd.conf; then
-  exit 0
+if ! crontab -l 2>/dev/null | grep -q CUPS-QUEUE-PURGE; then
+	crontab <(crontab -l 2>/dev/null; echo -en "\n# CUPS-QUEUE-PURGE: ensure that print jobs are cleaned out after they're expired\n* * * * * /usr/bin/lpstat -W completed -o")
 fi
-
-echo "PreserveJobHistory Off" | sudo tee -a /etc/cups/cupsd.conf
-
-sudo launchctl unload /System/Library/LaunchDaemons/org.cups.cupsd.plist
-
-sudo launchctl load /System/Library/LaunchDaemons/org.cups.cupsd.plist
-EOF
 ```
-
-### Step 4: make `cups.sh` executable
-
-```shell
-chmod +x /usr/local/sbin/cups.sh
-```
-
-### Step 5: create `local.cups.plist` launch daemon
-
-```shell
-cat << "EOF" | sudo tee /Library/LaunchDaemons/local.cups.plist
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-  <dict>
-    <key>Label</key>
-    <string>local.cups</string>
-
-    <key>ProgramArguments</key>
-    <array>
-        <string>/usr/local/sbin/cups.sh</string>
-    </array>
-
-    <key>RunAtLoad</key>
-    <true/>
-  </dict>
-</plist>
-EOF
-```
-
-### Step 6: reboot
 
 👍
 
@@ -90,32 +58,10 @@ EOF
 
 ## Want things back the way they were before following this guide? No problem!
 
-### Step 1: delete `PreserveJobHistory Off` line from `cupsd.conf`
+### Step 1:  Reset config parameters to defaults
 
 ```shell
-sudo sed -i "" "/PreserveJobHistory Off/d" /etc/cups/cupsd.conf
+$  cupsctl MaxJobTime= PreserveJobFiles= PreserveJobHistory=
 ```
-
-### Step 2: delete `cups.sh` script
-
-```shell
-sudo rm /usr/local/sbin/cups.sh
-```
-
-### Step 3: delete `local.cups.plist` launch daemon
-
-```shell
-sudo rm /Library/LaunchDaemons/local.cups.plist
-```
-
-### Step 4: reload CUPS
-
-```shell
-sudo launchctl unload /System/Library/LaunchDaemons/org.cups.cupsd.plist
-
-sudo launchctl load /System/Library/LaunchDaemons/org.cups.cupsd.plist
-```
-
-### Step 5: reboot
 
 👍

--- a/how-to-disable-cups-printer-job-history-on-macos/README.md
+++ b/how-to-disable-cups-printer-job-history-on-macos/README.md
@@ -41,7 +41,7 @@ cat << "EOF" > /usr/local/sbin/cups.sh
 
 set -e
 
-if cupsctl | grep PreserveJobHistory=no > /dev/null 2>&1; then
+if cupsctl | grep --quiet PreserveJobHistory=no; then
   exit 0
 fi
 


### PR DESCRIPTION
Use `cupsctl`  to make cupsd config changes, and `lpstat -W completed -o` in a cronjob to ensure configured pruning without purging active jobs.